### PR TITLE
Use HTTPS for d3

### DIFF
--- a/lib/nyaplot/core.rb
+++ b/lib/nyaplot/core.rb
@@ -3,7 +3,7 @@ require 'erb'
 module Nyaplot
 
   @@dep_libraries = {
-    d3:'http://d3js.org/d3.v3.min',
+    d3:'https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min',
     downloadable: 'http://cdn.rawgit.com/domitry/d3-downloadable/master/d3-downloadable'
   }
   @@additional_libraries = {}


### PR DESCRIPTION
In order for scripts to be loaded when the Jupyter notebook server is served over HTTPS, scripts need to fetched from HTTPS as well. Chrome for instance will actively block HTTP scripts when a domain is served over HTTPS.

![screenshot 2015-06-03 16 00 42](https://cloud.githubusercontent.com/assets/836375/7971338/b438b6da-0a09-11e5-8ebd-01c801de9f9c.png)

Note that the cdnjs URL is the "canonical" URL that http://d3js.org/ lists. If there are other resources that need to be fixed, those should be addressed too. For me, this meant not being able to load the IRuby example notebook. /cc @minad 