### PR TITLE
Allow Travis failures in ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ rvm:
   - 2.3.0
   - 2.2.4
   - 2.1.8
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true


### PR DESCRIPTION
ruby-head is error-prone, so this change would allow more accurate information from the build badge.
